### PR TITLE
Add support for different composer directory

### DIFF
--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -58,8 +58,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh composer "$@"
+    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh composer "$@"
+    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,6 +38,15 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
+COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
+if [[ "$#" != 0 ]]; then
+    for i in "$@"; do
+        if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
+            COMPOSER_WORKDIR_PARAM=""
+        fi
+    done
+fi
+
 if [[ "$#" != 0 \
     && ( "${MACHINE}" == "mac" || "${MACHINE}" == "windows" ) \
     && ( "$1" == "install" || "$1" == "update" || "$1" == "require" || "$1" == "remove" ) ]]
@@ -58,8 +67,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
+    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
+    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -39,10 +39,11 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
 fi
 
 COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
-if [[ "$#" != 0 ]]; then
+if [ "$#" != 0 ]; then
     for i in "$@"; do
         if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
             COMPOSER_WORKDIR_PARAM=""
+            break
         fi
     done
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,10 +38,10 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
-COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
+COMPOSER_WORKDIR_PARAM=" -d ${COMPOSER_DIR}"
 if [ "$#" != 0 ]; then
     for i in "$@"; do
-        if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
+        if [[ "$i" == "-d" || "$i" == "--working-dir" ]]; then
             COMPOSER_WORKDIR_PARAM=""
             break
         fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -39,13 +39,12 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
 fi
 
 COMPOSER_WORKDIR_PARAM=" -d ${COMPOSER_DIR}"
-if [ "$#" != 0 ]; then
-    for i in "$@"; do
-        if [[ "$i" == "-d" || "$i" == "--working-dir" ]]; then
-            COMPOSER_WORKDIR_PARAM=""
-            break
-        fi
-    done
+if [[ "$#" != 0 \
+    && ( $@ == *" -d "*  || $@ == *" -d="* \
+        || $@ == "-d "* || $@ == "-d="*  \
+        || $@ == *" --working-dir "* || $@ == *" --working-dir="*   \
+        || $@ == "--working-dir "* || $@ == " --working-dir="* ) ]]; then
+    COMPOSER_WORKDIR_PARAM=""
 fi
 
 if [[ "$#" != 0 \

--- a/console/commands/create-project.sh
+++ b/console/commands/create-project.sh
@@ -68,4 +68,4 @@ if [[ ${COMPOSER_EDITION_NEEDED} == true ]]; then
     exit 0
 fi
 
-${COMMANDS_DIR}/composer.sh install -d ${COMPOSER_DIR}
+${COMMANDS_DIR}/composer.sh install


### PR DESCRIPTION
**Pre-conditions**
 - real Magento installed in magento2/ directory of the project root.

Run `dockergento setup` in the project root.
When it it asking for magento directory and composer directory - type "magento2/".

After installation - try to run `dockergento composer install`. Now it fails, because composer runs in project root, not in root/magento2/.

This PR fixes this issue