### PR TITLE
Add support for different composer directory

### DIFF
--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -44,7 +44,11 @@ if [[ "$#" != 0 \
         || $@ == "-d "* || $@ == "-d="*  \
         || $@ == *" --working-dir "* || $@ == *" --working-dir="*   \
         || $@ == "--working-dir "* || $@ == "--working-dir="* ) ]]; then
-    COMPOSER_WORKDIR_PARAM=""
+     printf "${COLOR_RED}Composer directory option not compatible with dockergento. This option is automatically set: ${COLOR_RESET}\n"
+     echo ""
+     echo "    --working-dir=${COMPOSER_DIR}"
+     echo ""
+     exit 1
 fi
 
 if [[ "$#" != 0 \

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -71,7 +71,7 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
+    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_WORKDIR_PARAM} 
     sync_all_from_container_to_host
 else
     ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -58,8 +58,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh composer "$@"
+    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh composer "$@"
+    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -74,5 +74,5 @@ then
     ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION} 
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_DIR_OPTION} "$@"
+    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION} 
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,6 +38,15 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
+COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
+if [[ "$#" != 0 ]]; then
+    for i in "$@"; do
+        if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
+            COMPOSER_WORKDIR_PARAM=""
+        fi
+    done
+fi
+
 if [[ "$#" != 0 \
     && ( "${MACHINE}" == "mac" || "${MACHINE}" == "windows" ) \
     && ( "$1" == "install" || "$1" == "update" || "$1" == "require" || "$1" == "remove" ) ]]
@@ -58,8 +67,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
+    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh sh -c "cd ${COMPOSER_DIR} && composer $@"
+    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -43,7 +43,7 @@ if [[ "$#" != 0 \
     && ( $@ == *" -d "*  || $@ == *" -d="* \
         || $@ == "-d "* || $@ == "-d="*  \
         || $@ == *" --working-dir "* || $@ == *" --working-dir="*   \
-        || $@ == "--working-dir "* || $@ == " --working-dir="* ) ]]; then
+        || $@ == "--working-dir "* || $@ == "--working-dir="* ) ]]; then
     COMPOSER_WORKDIR_PARAM=""
 fi
 

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,7 +38,7 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
-COMPOSER_DIR_OPTION=" --working-dir=${COMPOSER_DIR}"
+COMPOSER_DIR_OPTION="--working-dir=${COMPOSER_DIR}"
 if [[ "$#" != 0 \
     && ( $@ == *" -d "*  || $@ == *" -d="* \
         || $@ == "-d "* || $@ == "-d="*  \
@@ -56,7 +56,7 @@ if [[ "$#" != 0 \
     && ( "$1" == "install" || "$1" == "update" || "$1" == "require" || "$1" == "remove" ) ]]
 then
     printf "${GREEN}Validating composer before doing anything${COLOR_RESET}\n"
-    VALIDATION_OUTPUT=$(${COMMANDS_DIR}/exec.sh composer validate) \
+    VALIDATION_OUTPUT=$(${COMMANDS_DIR}/exec.sh composer validate ${COMPOSER_DIR_OPTION}) \
      || if [ $? == 1 ]; then echo "${VALIDATION_OUTPUT}"; exit 1; fi
 
     MAGENTO2_MODULE_PATH="${MAGENTO_DIR}/vendor/magento/magento2-base"
@@ -71,8 +71,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION} 
+    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION}
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION} 
+    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION}
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,7 +38,7 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
-COMPOSER_WORKDIR_PARAM=" --working-dir=${COMPOSER_DIR}"
+COMPOSER_DIR_OPTION=" --working-dir=${COMPOSER_DIR}"
 if [[ "$#" != 0 \
     && ( $@ == *" -d "*  || $@ == *" -d="* \
         || $@ == "-d "* || $@ == "-d="*  \
@@ -71,8 +71,8 @@ then
     fi
 
     mirror_vendor_host_into_container
-    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_WORKDIR_PARAM} 
+    ${COMMANDS_DIR}/exec.sh composer "$@" ${COMPOSER_DIR_OPTION} 
     sync_all_from_container_to_host
 else
-    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_WORKDIR_PARAM} "$@"
+    ${COMMANDS_DIR}/exec.sh composer ${COMPOSER_DIR_OPTION} "$@"
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -39,10 +39,11 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
 fi
 
 COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
-if [[ "$#" != 0 ]]; then
+if [ "$#" != 0 ]; then
     for i in "$@"; do
         if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
             COMPOSER_WORKDIR_PARAM=""
+            break
         fi
     done
 fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,10 +38,10 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
-COMPOSER_WORKDIR_PARAM=" -w ${COMPOSER_DIR}"
+COMPOSER_WORKDIR_PARAM=" -d ${COMPOSER_DIR}"
 if [ "$#" != 0 ]; then
     for i in "$@"; do
-        if [[ "$i" == "-w" || "$i" == "--working-dir" ]]; then
+        if [[ "$i" == "-d" || "$i" == "--working-dir" ]]; then
             COMPOSER_WORKDIR_PARAM=""
             break
         fi

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -38,7 +38,7 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
         exit 1
 fi
 
-COMPOSER_WORKDIR_PARAM=" -d ${COMPOSER_DIR}"
+COMPOSER_WORKDIR_PARAM=" --working-dir=${COMPOSER_DIR}"
 if [[ "$#" != 0 \
     && ( $@ == *" -d "*  || $@ == *" -d="* \
         || $@ == "-d "* || $@ == "-d="*  \

--- a/console/commands/composer.sh
+++ b/console/commands/composer.sh
@@ -39,13 +39,12 @@ if [[ "$#" != 0 && "$1" == "create-project" ]]; then
 fi
 
 COMPOSER_WORKDIR_PARAM=" -d ${COMPOSER_DIR}"
-if [ "$#" != 0 ]; then
-    for i in "$@"; do
-        if [[ "$i" == "-d" || "$i" == "--working-dir" ]]; then
-            COMPOSER_WORKDIR_PARAM=""
-            break
-        fi
-    done
+if [[ "$#" != 0 \
+    && ( $@ == *" -d "*  || $@ == *" -d="* \
+        || $@ == "-d "* || $@ == "-d="*  \
+        || $@ == *" --working-dir "* || $@ == *" --working-dir="*   \
+        || $@ == "--working-dir "* || $@ == " --working-dir="* ) ]]; then
+    COMPOSER_WORKDIR_PARAM=""
 fi
 
 if [[ "$#" != 0 \

--- a/console/commands/create-project.sh
+++ b/console/commands/create-project.sh
@@ -68,4 +68,4 @@ if [[ ${COMPOSER_EDITION_NEEDED} == true ]]; then
     exit 0
 fi
 
-${COMMANDS_DIR}/composer.sh install -d ${COMPOSER_DIR}
+${COMMANDS_DIR}/composer.sh install


### PR DESCRIPTION
**Pre-conditions**
 - real Magento installed in magento2/ directory of the project root.

Run `dockergento setup` in the project root.
When it it asking for magento directory and composer directory - type "magento2/".

After installation - try to run `dockergento composer install`. Now it fails, because composer runs in project root, not in root/magento2/.

This PR fixes this issue.


This PR is fixed version of https://github.com/ModestCoders/magento2-dockergento/pull/25
+ fixed issue described in https://github.com/ModestCoders/magento2-dockergento/pull/25#issuecomment-435028588 + this issue investigation results here https://github.com/ModestCoders/magento2-dockergento/pull/25#issuecomment-437315941
+ fixed issue when used `dockergento composer --working-dir=. install` command