### PR TITLE
fix #38, fix nginx Request Entity Too Large Error

### DIFF
--- a/config/dockergento/nginx/conf/default.conf
+++ b/config/dockergento/nginx/conf/default.conf
@@ -16,7 +16,8 @@ server {
   listen 8000;
   ## Add here your domains or leave "localhost" wildcard
   server_name localhost;
-
+  # set client body size to 2M 
+  client_max_body_size 2M;
   set $MAGE_ROOT /var/www/html;
   set $MAGE_MODE developer;
   set $MAGE_RUN_TYPE website;


### PR DESCRIPTION
https://www.cyberciti.biz/faq/linux-unix-bsd-nginx-413-request-entity-too-large/