### PR TITLE
Fix product saving issues

### DIFF
--- a/config/dockergento/nginx/conf/default.conf
+++ b/config/dockergento/nginx/conf/default.conf
@@ -179,6 +179,7 @@ server {
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
     fastcgi_param  PHP_VALUE "max_execution_time=600";
+    fastcgi_param  PHP_VALUE "max_input_vars=10000";
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
     fastcgi_param  MAGE_MODE $MAGE_MODE;


### PR DESCRIPTION
### Description
When I used dockergento on my project I got an issue with saving products. I investigated it and found solution:
https://devdocs.magento.com/guides/v2.3/install-gde/trouble/php/tshoot_php-set.html#max-input-vars-error-due-to-large-forms

### Related issues
- https://github.com/magento/magento2/issues/9317
- https://github.com/magento/devdocs/issues/1527
- https://github.com/magento/devdocs/pull/3596

### What was done
Increased value of max_input_vars option from 1000 (default value) to 10000.

