### PR TITLE
change php fpm image

### DIFF
--- a/docker-compose/docker-compose.sample.yml
+++ b/docker-compose/docker-compose.sample.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   phpfpm:
-    image: modestcoders/php:7.1-fpm-1
+    image: modestcoders/php:7.1-fpm
     volumes: &appvolumes
       - sockdata:/sock
       - ../.composer:/var/www/.composer:delegated


### PR DESCRIPTION
This change will allow to update the images without the need of appending version number into the image name. The image 7.x-fpm will always be the latest version of the image.