### PR TITLE
 Speed up debug on and off

### DIFF
--- a/console/commands/debug-off.sh
+++ b/console/commands/debug-off.sh
@@ -5,7 +5,6 @@ ${TASKS_DIR}/start_service_if_not_running.sh ${SERVICE_PHP}
 
 ${COMMANDS_DIR}/exec.sh sed -i -e 's/^\zend_extension/;zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-${COMMANDS_DIR}/stop.sh
-${COMMANDS_DIR}/start.sh
+${DOCKER_COMPOSE} restart ${SERVICE_PHP}
 
 printf "> ${GREEN}xdebug disabled${COLOR_RESET}\n"

--- a/console/commands/debug-on.sh
+++ b/console/commands/debug-on.sh
@@ -7,7 +7,7 @@ if [[ "${MACHINE}" == 'linux' && "${XDEBUG_HOST:-}" == "" ]]; then
     source ${TASKS_DIR}/set_xdebug_host_property.sh
 fi
 if [[ "${XDEBUG_HOST:-}" != "" ]]; then
-    ${COMMANDS_DIR}/exec.sh --root sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=${XDEBUG_HOST}/g" /usr/local/etc/php/conf.d/xdebug.ini
+    ${COMMANDS_DIR}/exec.sh sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=${XDEBUG_HOST}/g" /usr/local/etc/php/conf.d/xdebug.ini
 fi
 
 ${COMMANDS_DIR}/exec.sh sed -i -e 's/^\;zend_extension/zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini

--- a/console/commands/debug-on.sh
+++ b/console/commands/debug-on.sh
@@ -16,9 +16,9 @@ if [[ "${MACHINE}" == "mac" || "${MACHINE}" == "windows" ]]; then
     printf "${YELLOW}Copying generated code into host ${COLOR_RESET}\n"
     ${COMMANDS_DIR}/mirror-container.sh -f ${GENERATED_DIR}
     # No need to restart because mirror-container.sh already does a restart
-    # ${COMMANDS_DIR}/restart.sh
+    # ${DOCKER_COMPOSE} restart ${SERVICE_PHP}
 else
-    ${COMMANDS_DIR}/restart.sh
+    ${DOCKER_COMPOSE} restart ${SERVICE_PHP}
 fi
 
 printf "${YELLOW}xdebug configuration: ${COLOR_RESET}\n"


### PR DESCRIPTION
- Restart only php container after changing xdebug settings
- Stop using --root flag when it's not needed