### PR TITLE
fix bad permissions being set when UID is no 1000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Version](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+ * Linux: permission fix not running on rebuild
+ * Linux: now correct permissions are set when UID is not 1000
 
 ## [4.0.0] - 2019-09-26
 ### Added

--- a/console/commands/rebuild.sh
+++ b/console/commands/rebuild.sh
@@ -12,3 +12,12 @@ else
 fi
 
 ${TASKS_DIR}/validate_bind_mounts.sh
+
+echo "Waiting for everything to spin up..."
+sleep 5
+
+if [[ "${MACHINE}" == "linux" ]]; then
+    echo " > fixing permissions"
+    ${TASKS_DIR}/fix_linux_permissions.sh
+    echo " > permissions fix finished"
+fi

--- a/console/tasks/fix_linux_permissions.sh
+++ b/console/tasks/fix_linux_permissions.sh
@@ -22,7 +22,7 @@ match_user_id_between_host_and_container ()
 {
     SERVICE=$1
     CONTAINER_UID=$(${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "getent passwd ${USER_PHP} | cut -f3 -d:")
-    HOST_UID=$(${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "stat -c '%u' '.'")
+    HOST_UID=$(id -u "$USER")
 
     if [[ ${HOST_UID} == '0' ]]; then
         printf "${RED}Error: Something is wrong, HOST_UID cannot have id 0 (root).${COLOR_RESET}\n"
@@ -41,7 +41,7 @@ match_group_id_between_host_and_container ()
 {
     SERVICE=$1
     CONTAINER_GID=$(${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "getent group ${GROUP_PHP} | cut -f3 -d:")
-    HOST_GID=$(${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "stat -c '%g' '.'")
+    HOST_GID=$(id -g "$USER")
 
     if [[ ${HOST_GID} == '0' ]]; then
         printf "${RED}Error: Something is wrong, HOST_UID cannot have id 0 (root).${COLOR_RESET}\n"
@@ -51,7 +51,7 @@ match_group_id_between_host_and_container ()
         echo " > changing GID of ${USER_PHP} from ${CONTAINER_GID} to ${HOST_GID} in ${SERVICE} service"
         prepare_container_to_change_user_ids "${SERVICE}"
         ${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "groupmod -g ${HOST_GID} -o ${GROUP_PHP}"
-        ${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "find / -xdev -user '${CONTAINER_GID}' -exec chown -h '${USER_PHP}' {} \;"
+        ${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "find / -xdev -user '${CONTAINER_GID}' -exec chgrp -h '${USER_PHP}' {} \;"
     fi
 }
 


### PR DESCRIPTION
When UID is not equal to 1000 at host, the UID inside container is not being updated correctly.

When containers are rebuilt they begin with UID and GID 1000, so this command `$(${DOCKER_ROOT_COMMAND} ${SERVICE} sh -c "stat -c '%u' '.'")` is returning the UID/GID of app user (1000) because they belong to that user at this specific moment.

So I've changed the way dockergento gets the UID/GID of the actual user to: `$(id -u "$USER")` which takes the actual user running the comand.

Also there was a bug when updating the group of files: we need to use `chgrp` instead of `chown`.

I've also added the permission fix to `dockergento rebuild` command, because when containers are restarted using rebuild, they could've wrong permissions.