### PR TITLE
PhpFpmDebug

### DIFF
--- a/config/dockergento/nginx/conf/default.conf
+++ b/config/dockergento/nginx/conf/default.conf
@@ -8,8 +8,15 @@ map $http_host $MAGE_RUN_CODE {
     # dominio-de.lo    de;
 }
 
-upstream fastcgi_backend {
-  server unix:/sock/docker.sock;
+# default Docker DNS server
+resolver 127.0.0.11;
+
+map $cookie_XDEBUG_SESSION $my_fastcgi_pass {
+    default phpfpm;
+    XDEBUG_ECLIPSE phpfpmdebug;
+    PHPSTORM phpfpmdebug;
+    netbeans-xdebug phpfpmdebug;
+    macgdbp phpfpmdebug;
 }
 
 server {
@@ -41,7 +48,7 @@ server {
     root $MAGE_ROOT;
     location ~ ^/setup/index.php {
       fastcgi_split_path_info ^(.+\.php)(/.+)$;
-      fastcgi_pass   fastcgi_backend;
+      fastcgi_pass   $my_fastcgi_pass:9001;
 
       fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
       fastcgi_param  PHP_VALUE "memory_limit=756M \n max_execution_time=600";
@@ -68,7 +75,7 @@ server {
 
     location ~ ^/update/index.php {
       fastcgi_split_path_info ^(/update/index.php)(/.+)$;
-      fastcgi_pass   fastcgi_backend;
+      fastcgi_pass   $my_fastcgi_pass:9001;
       fastcgi_index  index.php;
       fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
       fastcgi_param  PATH_INFO        $fastcgi_path_info;
@@ -174,7 +181,7 @@ server {
   # PHP entry point for main application
   location ~ ^/(index|get|static|errors/report|errors/404|errors/503|health_check)\.php$ {
     try_files $uri =404;
-    fastcgi_pass   fastcgi_backend;
+    fastcgi_pass   $my_fastcgi_pass:9001;
     fastcgi_buffers 1024 4k;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";

--- a/config/dockergento/usr/local/etc/php-fpm.conf
+++ b/config/dockergento/usr/local/etc/php-fpm.conf
@@ -1,0 +1,31 @@
+; This file was initially adapated from the output of: (on PHP 5.6)
+;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
+
+[global]
+
+error_log = /proc/self/fd/2
+daemonize = no
+
+[www]
+
+; if we send this to /proc/self/fd/1, it never appears
+access.log = /proc/self/fd/2
+
+;user = app
+;group = app
+
+listen = 9001
+listen.owner = app
+listen.group = app
+listen.mode = 0660
+
+pm = dynamic
+pm.max_children = 10
+pm.start_servers = 4
+pm.min_spare_servers = 2
+pm.max_spare_servers = 6
+
+clear_env = no
+
+; Ensure worker stdout and stderr are sent to the main error log.
+catch_workers_output = yes

--- a/config/dockergento/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+++ b/config/dockergento/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
@@ -1,0 +1,1 @@
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so

--- a/config/dockergento/usr/local/etc/php/conf.d/xdebug.ini
+++ b/config/dockergento/usr/local/etc/php/conf.d/xdebug.ini
@@ -1,0 +1,7 @@
+xdebug.idekey=PHPSTORM
+xdebug.remote_autostart=0
+xdebug.remote_connect_back=0
+xdebug.remote_enable=1
+xdebug.remote_host=host.docker.internal
+xdebug.remote_port=9000
+xdebug.max_nesting_level=500

--- a/docker-compose/docker-compose.dev.mac.sample.yml
+++ b/docker-compose/docker-compose.dev.mac.sample.yml
@@ -1,8 +1,9 @@
 version: "3.7"
 
 services:
-  phpfpm:
-    volumes: &appvolumes-mac
+  nginx:
+    volumes:
+      &appvolumes-mac
       - workspace:/var/www/html
       - ./app:/var/www/html/app:delegated
       - ./.git:/var/www/html/.git:delegated
@@ -11,8 +12,19 @@ services:
       - ./composer.lock:/var/www/html/composer.lock:delegated
       # {FILES_IN_GIT}
 
-  nginx:
+  phpfpm:
     volumes: *appvolumes-mac
+
+  phpfpmdebug:
+    volumes:
+      - workspace:/var/www/html
+      - ./app:/var/www/html/app:delegated
+      - ./.git:/var/www/html/.git:delegated
+      - ./config:/var/www/html/config:delegated
+      - ./composer.json:/var/www/html/composer.json:delegated
+      - ./composer.lock:/var/www/html/composer.lock:delegated
+      - ./config/dockergento/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini:delegated
+      - ./config/dockergento/usr/local/etc/php/conf.d/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini:delegated
 
   node:
     volumes: *appvolumes-mac
@@ -28,6 +40,7 @@ services:
       - SYNC_MAX_INOTIFY_WATCHES=60000
     depends_on:
       - phpfpm
+      - phpfpmdebug
     privileged: true
 
 volumes:

--- a/docker-compose/docker-compose.sample.yml
+++ b/docker-compose/docker-compose.sample.yml
@@ -1,26 +1,37 @@
 version: "3.7"
 
 services:
-  phpfpm:
-    image: modestcoders/php:7.1-fpm
+
+  nginx:
+    image: modestcoders/nginx:1.13
+    ports:
+      - 80:8000
     volumes: &appvolumes
-      - sockdata:/sock
       - ../.composer:/var/www/.composer:delegated
       - ../.composer:/var/www/html/var/composer_home:delegated
-      - ./config/dockergento/nginx/conf/default.conf:/var/www/conf/nginx/default.conf:delegated
+      - ./config/dockergento/nginx/conf/default.conf:/etc/nginx/conf.d/default.conf:delegated
+      - ./config/dockergento/usr/local/etc/php-fpm.conf:/usr/local/etc/php-fpm.conf:delegated
+    depends_on:
+      - phpfpm
+      - phpfpmdebug
+
+  phpfpm:
+    image: modestcoders/php:7.2-fpm
+    volumes: *appvolumes
     environment:
       PHP_IDE_CONFIG: serverName=localhost
     depends_on:
       - db
       - elasticsearch
 
-  nginx:
-    image: modestcoders/nginx:1.13
-    ports:
-      - 80:8000
+  phpfpmdebug:
+    image: modestcoders/php:7.2-fpm
     volumes: *appvolumes
+    environment:
+      PHP_IDE_CONFIG: serverName=localhost
     depends_on:
-      - phpfpm
+      - db
+      - elasticsearch
 
   db:
     image: mysql:5.7


### PR DESCRIPTION
Introduces `phpfpmdebug` service, nginx routes calls to this service based on whether the XDEBUG_SESSION cookie is set. This speeds up the development process as there's no need to run `debug-on` & `debug-off` commands anymore.

See for more details: https://jtreminio.com/blog/developing-at-full-speed-with-xdebug/