### PR TITLE
Elasticsearch - improve persistence & run in single node mode

### DIFF
--- a/docker-compose/docker-compose.sample.yml
+++ b/docker-compose/docker-compose.sample.yml
@@ -44,7 +44,12 @@ services:
 
   elasticsearch:
     image: modestcoders/elasticsearch:6.5
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
 
 volumes:
   dbdata:
   sockdata:
+  elasticsearch_data:


### PR DESCRIPTION
This PR improves following things:
1. Once you run `dockergento down` & `dockergento start` - earlier data in Elasticsearch was lost and you have yo run full reindex again. This PR creates docker volume that will be re-used for Elasticsearch data

2. It sets Elasticsearch to single node mode, so it will not try to find other nodes in cluster. More details: https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-settings.html