### PR TITLE
Add ability to choose Magento 2 edition during project creation

### DIFF
--- a/console/commands/create-project.sh
+++ b/console/commands/create-project.sh
@@ -1,41 +1,54 @@
 #!/bin/bash
 set -euo pipefail
 
-usage()
-{
-    printf "${YELLOW}Usage:${COLOR_RESET}\n"
-    echo "  create-project"
-    echo ""
-    printf "${YELLOW}Description:${COLOR_RESET}\n"
-    echo "  This command creates a new magento project from scratch"
+usage() {
+  printf "${YELLOW}Usage:${COLOR_RESET}\n"
+  echo "  create-project"
+  echo ""
+  printf "${YELLOW}Description:${COLOR_RESET}\n"
+  echo "  This command creates a new magento project from scratch"
 }
 
 if [ "$#" != 0 ] && [ "$1" == "--help" ]; then
-    usage
-    exit 0
+  usage
+  exit 0
 fi
 
-overwrite_file_consent()
-{
-    TARGET_FILE=$1
+overwrite_file_consent() {
+  TARGET_FILE=$1
 
-    if [[ -f "${TARGET_FILE}" ]]; then
-        read -p "overwrite ${TARGET_FILE}? (y/n [n])? " ANSWER_OVERWRITE_TARGET
-        if [ "${ANSWER_OVERWRITE_TARGET}" != "y" ]; then
-            printf "${RED} Setup interrupted. This commands needs to overwrite this file.${COLOR_RESET}\n"
-            exit 1
-        fi
+  if [[ -f "${TARGET_FILE}" ]]; then
+    read -p "overwrite ${TARGET_FILE}? (y/n [n])? " ANSWER_OVERWRITE_TARGET
+    if [ "${ANSWER_OVERWRITE_TARGET}" != "y" ]; then
+      printf "${RED} Setup interrupted. This commands needs to overwrite this file.${COLOR_RESET}\n"
+      exit 1
     fi
+  fi
 }
 
 overwrite_file_consent "${COMPOSER_DIR}/composer.json"
 overwrite_file_consent ".gitignore"
+
+AVAILABLE_MAGENTO_EDITIONS="community enterprise"
+DEFAULT_MAGENTO_EDITION="community"
+
+read -p "Magento edition (community/enterprise [$DEFAULT_MAGENTO_EDITION]): " MAGENTO_EDITION
+
+if [[ $MAGENTO_EDITION == '' ]]; then
+  MAGENTO_EDITION=$DEFAULT_MAGENTO_EDITION
+fi
+
+if ! $(${TASKS_DIR}/in_list.sh "${MAGENTO_EDITION}" "${AVAILABLE_MAGENTO_EDITIONS}") ; then
+  printf "${RED} Setup interrupted. Invalid edition '${MAGENTO_EDITION}' ${COLOR_RESET}\n"
+  exit 1
+fi
+
 read -p "Magento version: " MAGENTO_VERSION
 
 ${TASKS_DIR}/start_service_if_not_running.sh ${SERVICE_APP}
 
 CREATE_PROJECT_TMP_DIR="dockergento-create-project-tmp"
-${COMMANDS_DIR}/exec.sh composer create-project --no-install --repository=https://repo.magento.com/ magento/project-community-edition ${CREATE_PROJECT_TMP_DIR} ${MAGENTO_VERSION}
+${COMMANDS_DIR}/exec.sh composer create-project --no-install --repository=https://repo.magento.com/ magento/project-${MAGENTO_EDITION}-edition ${CREATE_PROJECT_TMP_DIR} ${MAGENTO_VERSION}
 
 echo " > Copying project files into host"
 ${COMMANDS_DIR}/exec.sh sh -c "cat ${CREATE_PROJECT_TMP_DIR}/composer.json > ${COMPOSER_DIR}/composer.json"
@@ -47,25 +60,25 @@ echo ""
 
 COMPOSER_EDITION_NEEDED=false
 if [[ "${MAGENTO_DIR}" != "${COMPOSER_DIR}" ]]; then
-    COMPOSER_EDITION_NEEDED=true
-    printf "${YELLOW}Warning:${COLOR_RESET} magento dir is not the same as composer dir\n"
-    echo "  Magento dir: '${MAGENTO_DIR}'"
-    echo "  Composer dir: '${COMPOSER_DIR}'"
+  COMPOSER_EDITION_NEEDED=true
+  printf "${YELLOW}Warning:${COLOR_RESET} magento dir is not the same as composer dir\n"
+  echo "  Magento dir: '${MAGENTO_DIR}'"
+  echo "  Composer dir: '${COMPOSER_DIR}'"
 fi
 
 if [[ "${MAGENTO_DIR}/vendor/bin" != "${BIN_DIR}" ]]; then
-    COMPOSER_EDITION_NEEDED=true
-    printf "${YELLOW}Warning:${COLOR_RESET} bin dir is not inside magento dir\n"
-    echo "  Magento dir: '${MAGENTO_DIR}'"
-    echo "  Bin dir: '${BIN_DIR}'"
+  COMPOSER_EDITION_NEEDED=true
+  printf "${YELLOW}Warning:${COLOR_RESET} bin dir is not inside magento dir\n"
+  echo "  Magento dir: '${MAGENTO_DIR}'"
+  echo "  Bin dir: '${BIN_DIR}'"
 fi
 
 if [[ ${COMPOSER_EDITION_NEEDED} == true ]]; then
-    printf "${YELLOW}Edit ${COMPOSER_DIR}/composer.json accordingly and execute:\n"
-    echo ""
-    echo "  dockergento composer install"
-    echo ""
-    exit 0
+  printf "${YELLOW}Edit ${COMPOSER_DIR}/composer.json accordingly and execute:\n"
+  echo ""
+  echo "  dockergento composer install"
+  echo ""
+  exit 0
 fi
 
 ${COMMANDS_DIR}/composer.sh install

--- a/console/commands/create-project.sh
+++ b/console/commands/create-project.sh
@@ -48,6 +48,7 @@ read -p "Magento version: " MAGENTO_VERSION
 ${TASKS_DIR}/start_service_if_not_running.sh ${SERVICE_APP}
 
 CREATE_PROJECT_TMP_DIR="dockergento-create-project-tmp"
+${COMMANDS_DIR}/exec.sh sh -c "rm -rf ${CREATE_PROJECT_TMP_DIR}/*"
 ${COMMANDS_DIR}/exec.sh composer create-project --no-install --repository=https://repo.magento.com/ magento/project-${MAGENTO_EDITION}-edition ${CREATE_PROJECT_TMP_DIR} ${MAGENTO_VERSION}
 
 echo " > Copying project files into host"


### PR DESCRIPTION
# Description
This PR is related to #70.

# How to test
- Run `dockergento create project`
- In order to choose Magento edition type `community` or `enterprise` 
- If any edition is specified `community` should be used as default