### PR TITLE
[WSL2] Correctly detect host IP address

### DIFF
--- a/console/tasks/set_xdebug_host_property.sh
+++ b/console/tasks/set_xdebug_host_property.sh
@@ -5,6 +5,8 @@ XDEBUG_HOST=""
 if [ "${MACHINE}" == "linux" ]; then
     if grep -q Microsoft /proc/version; then # WSL
         XDEBUG_HOST=10.0.75.1
+    elif grep -q microsoft-standard /proc/version; then #WSL2
+        XDEBUG_HOST=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf)
     else
         if [ "$(command -v ip)" ]; then
             XDEBUG_HOST=$(ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)


### PR DESCRIPTION
### Description

I've tried to run dockergento on WSL2 (currently in release preview) + Docker Desktop for Windows and got following issue:
```bash
$ dockergento debug-on
Device "docker0" does not exist.
```

### Solution

Investigation showed that we need to have additional check to detect WSL2, everything else seems like works fine and pretty good using "linux" dockergento file, no additional checks needed.

So I just adapted detection of host machine IP address, see WSL1 and WSL2 examples here:
https://github.com/microsoft/WSL/issues/4555#issuecomment-536862561

### Additional info
Note: In case if you're running PhpStorm (or any other IDE) inside WSL2 using VcXsrv - XDebug will not work by default, additionally requires to forward xdebug port to host machine (here is related issue with description and workaround: https://github.com/microsoft/WSL/issues/4150#issuecomment-504209723). I've adapted that workaround for Dockergento, need running following PowerShell script as Administrator:

```powershell
$remoteport = bash.exe -c "ifconfig eth0 | grep 'inet '"
$found = $remoteport -match '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}';

if( $found ){
  $remoteport = $matches[0];
} else{
  echo "The Script Exited, the ip address of WSL 2 cannot be found";
  exit;
}

#[Ports]

#All the ports you want to forward separated by coma
$ports=@(9001);


#[Static ip]
#You can change the addr to your ip config to listen to a specific address
$addr='0.0.0.0';
$ports_a = $ports -join ",";


#Remove Firewall Exception Rules
iex "Remove-NetFireWallRule -DisplayName 'WSL 2 Firewall Unlock' ";

#adding Exception Rules for inbound and outbound Rules
iex "New-NetFireWallRule -DisplayName 'WSL 2 Firewall Unlock' -Direction Outbound -LocalPort $ports_a -Action Allow -Protocol TCP";
iex "New-NetFireWallRule -DisplayName 'WSL 2 Firewall Unlock' -Direction Inbound -LocalPort $ports_a -Action Allow -Protocol TCP";

for( $i = 0; $i -lt $ports.length; $i++ ){
  $port = $ports[$i];
  iex "netsh interface portproxy delete v4tov4 listenport=$port listenaddress=$addr";
  iex "netsh interface portproxy add v4tov4 listenport=$port listenaddress=$addr connectport=$port connectaddress=$remoteport";
}
```