### PR TITLE
WSL2 - Use host.docker.internal hostname instead of IP

### DIFF
--- a/console/tasks/set_xdebug_host_property.sh
+++ b/console/tasks/set_xdebug_host_property.sh
@@ -6,7 +6,7 @@ if [ "${MACHINE}" == "linux" ]; then
     if grep -q Microsoft /proc/version; then # WSL
         XDEBUG_HOST=10.0.75.1
     elif grep -q microsoft-standard /proc/version; then #WSL2
-        XDEBUG_HOST=$(awk '/nameserver / {print $2; exit}' /etc/resolv.conf)
+        XDEBUG_HOST=host.docker.internal
     else
         if [ "$(command -v ip)" ]; then
             XDEBUG_HOST=$(ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)


### PR DESCRIPTION
Replace detecting IP address to `host.docker.internal`, that described in the networking docs for docker for windows 